### PR TITLE
Bump version to 0.4.0 for TestPyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vcf-pg-loader"
-version = "0.3.0"
+version = "0.4.0"
 description = "High-performance VCF to PostgreSQL loader with clinical-grade compliance"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
Bump version from 0.3.0 to 0.4.0 because 0.3.0 already exists on TestPyPI.

## Test plan
- [ ] CI passes
- [ ] TestPyPI publish succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)